### PR TITLE
Added possibility to set a different service name

### DIFF
--- a/installer.go
+++ b/installer.go
@@ -21,9 +21,8 @@ func GetInitDPath(name string) string {
 func IsInitDScriptExist(name string) bool {
 	if _, err := os.Stat(GetInitDPath(name)); os.IsExist(err) {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 func GetInitDScript(folder, command, user string) (ret string, err error) {
@@ -91,7 +90,7 @@ func Install(user string, serviceName string) (rErr error) {
 
 	var script string
 	if IsInitDScriptExist(serviceName) {
-		rErr = errors.New(fmt.Sprintf("Script %s already exists in init.d folder", command))
+		rErr = fmt.Errorf("Script %s already exists in init.d folder", command)
 		return
 	}
 	if script, err = GetInitDScript(folder, command, user); nil != err {

--- a/installer.go
+++ b/installer.go
@@ -72,7 +72,7 @@ func MakeInitDExecutable(name string) (rErr error) {
 	return
 }
 
-func Install(user string) (rErr error) {
+func Install(user string, serviceName string) (rErr error) {
 	pathToExe, err := osext.Executable()
 	folder, command := filepath.Split(pathToExe)
 	if nil != err {
@@ -84,8 +84,13 @@ func Install(user string) (rErr error) {
 		rErr = errors.New("not yet supported")
 		return
 	}
+
+	if serviceName == "" {
+		serviceName = command
+	}
+
 	var script string
-	if IsInitDScriptExist(command) {
+	if IsInitDScriptExist(serviceName) {
 		rErr = errors.New(fmt.Sprintf("Script %s already exists in init.d folder", command))
 		return
 	}
@@ -93,7 +98,7 @@ func Install(user string) (rErr error) {
 		rErr = err
 		return
 	}
-	if fileWriteError := WriteInitD(command, script); nil != fileWriteError {
+	if fileWriteError := WriteInitD(serviceName, script); nil != fileWriteError {
 		rErr = fileWriteError
 		return
 	}
@@ -112,6 +117,7 @@ func Install(user string) (rErr error) {
 
 var install = flag.Bool("install", false, "install this program as service")
 var runAsUser = flag.String("installRunAsUser", "", "which user should the service run as")
+var serviceName = flag.String("serviceName", "", "[optional] service name")
 
 func Register(parse bool) {
 	if parse {
@@ -124,7 +130,7 @@ func Register(parse bool) {
 		fmt.Println("you must specify a user that the service runs as")
 		os.Exit(1)
 	}
-	if err := Install(*runAsUser); err != nil {
+	if err := Install(*runAsUser, *serviceName); err != nil {
 		fmt.Printf("installing as service failed: <%v> \n", err)
 		os.Exit(1)
 	}

--- a/installer.go
+++ b/installer.go
@@ -71,7 +71,7 @@ func MakeInitDExecutable(name string) (rErr error) {
 	return
 }
 
-func Install(user string, serviceName string) (rErr error) {
+func Install(user string) (rErr error) {
 	pathToExe, err := osext.Executable()
 	folder, command := filepath.Split(pathToExe)
 	if nil != err {
@@ -84,12 +84,12 @@ func Install(user string, serviceName string) (rErr error) {
 		return
 	}
 
-	if serviceName == "" {
-		serviceName = command
+	if *serviceName == "" {
+		*serviceName = command
 	}
 
 	var script string
-	if IsInitDScriptExist(serviceName) {
+	if IsInitDScriptExist(*serviceName) {
 		rErr = fmt.Errorf("Script %s already exists in init.d folder", command)
 		return
 	}
@@ -97,7 +97,7 @@ func Install(user string, serviceName string) (rErr error) {
 		rErr = err
 		return
 	}
-	if fileWriteError := WriteInitD(serviceName, script); nil != fileWriteError {
+	if fileWriteError := WriteInitD(*serviceName, script); nil != fileWriteError {
 		rErr = fileWriteError
 		return
 	}
@@ -129,7 +129,7 @@ func Register(parse bool) {
 		fmt.Println("you must specify a user that the service runs as")
 		os.Exit(1)
 	}
-	if err := Install(*runAsUser, *serviceName); err != nil {
+	if err := Install(*runAsUser); err != nil {
 		fmt.Printf("installing as service failed: <%v> \n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
 You can now set a different service name with console flag -serviceName [string]. (this is optional, default is still the binary name)
